### PR TITLE
Integrate Supabase persistence and OpenAuth login

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,9 @@
+# Supabase configuration
+VITE_SUPABASE_URL=
+VITE_SUPABASE_ANON_KEY=
+
+# OpenAuth configuration
+VITE_OPENAUTH_ISSUER=
+VITE_OPENAUTH_CLIENT_ID=
+# Optional override if you prefer a custom redirect URL
+VITE_OPENAUTH_REDIRECT_URI=http://localhost:5173/auth/callback

--- a/README.md
+++ b/README.md
@@ -36,6 +36,50 @@ npm i
 npm run dev
 ```
 
+## Connecting Supabase & OpenAuth
+
+This project now persists data in Supabase and delegates authentication to [Supabase OpenAuth](https://supabase.com/docs/guides/openauth).
+
+1. Copy `.env.example` to `.env.local` (or `.env`) and provide the credentials for your Supabase project:
+
+   ```sh
+   cp .env.example .env.local
+   ```
+
+   | Variable | Description |
+   | --- | --- |
+   | `VITE_SUPABASE_URL` | Supabase project URL |
+   | `VITE_SUPABASE_ANON_KEY` | Anonymous API key |
+   | `VITE_OPENAUTH_ISSUER` | OpenAuth issuer URL from the Supabase dashboard |
+   | `VITE_OPENAUTH_CLIENT_ID` | The client ID created for this web application |
+   | `VITE_OPENAUTH_REDIRECT_URI` | (Optional) override for the callback route, defaults to `/auth/callback` |
+
+2. In Supabase, create the tables used by the app:
+
+   ```sql
+   -- Stores profile metadata for authenticated users
+   create table if not exists public.profiles (
+     id text primary key,
+     email text,
+     display_name text,
+     avatar_color text,
+     bio text,
+     privacy text default 'friends',
+     updated_at timestamptz default now()
+   );
+
+   -- Stores the full tracker snapshot per user
+   create table if not exists public.tracker_snapshots (
+     user_id text primary key references public.profiles(id) on delete cascade,
+     snapshot jsonb not null,
+     updated_at timestamptz default now()
+   );
+   ```
+
+3. Enable OpenAuth in Supabase and configure at least one provider (email, Google, GitHub, etc.). Use the callback URL `http://localhost:5173/auth/callback` (or the URL defined in `VITE_OPENAUTH_REDIRECT_URI`).
+
+Once the environment variables are set the app will automatically use Supabase for persistence; without them it falls back to the local demo mode.
+
 **Edit a file directly in GitHub**
 
 - Navigate to the desired file(s).

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@fontsource/inter": "^5.2.8",
         "@hookform/resolvers": "^3.10.0",
+        "@openauthjs/openauth": "^0.4.3",
         "@radix-ui/react-accordion": "^1.2.11",
         "@radix-ui/react-alert-dialog": "^1.1.14",
         "@radix-ui/react-aspect-ratio": "^1.1.7",
@@ -37,6 +38,7 @@
         "@radix-ui/react-toggle": "^1.1.9",
         "@radix-ui/react-toggle-group": "^1.1.10",
         "@radix-ui/react-tooltip": "^1.2.7",
+        "@supabase/supabase-js": "^2.58.0",
         "@tanstack/react-query": "^5.83.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
@@ -950,6 +952,72 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/@openauthjs/openauth": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@openauthjs/openauth/-/openauth-0.4.3.tgz",
+      "integrity": "sha512-RlnjqvHzqcbFVymEwhlUEuac4utA5h4nhSK/i2szZuQmxTIqbGUxZ+nM+avM+VV4Ing+/ZaNLKILoXS3yrkOOw==",
+      "dependencies": {
+        "@standard-schema/spec": "1.0.0-beta.3",
+        "aws4fetch": "1.0.20",
+        "jose": "5.9.6"
+      },
+      "peerDependencies": {
+        "arctic": "^2.2.2",
+        "hono": "^4.0.0"
+      }
+    },
+    "node_modules/@oslojs/asn1": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@oslojs/asn1/-/asn1-1.0.0.tgz",
+      "integrity": "sha512-zw/wn0sj0j0QKbIXfIlnEcTviaCzYOY3V5rAyjR6YtOByFtJiT574+8p9Wlach0lZH9fddD4yb9laEAIl4vXQA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@oslojs/binary": "1.0.0"
+      }
+    },
+    "node_modules/@oslojs/binary": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@oslojs/binary/-/binary-1.0.0.tgz",
+      "integrity": "sha512-9RCU6OwXU6p67H4NODbuxv2S3eenuQ4/WFLrsq+K/k682xrznH5EVWA7N4VFk9VYVcbFtKqur5YQQZc0ySGhsQ==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@oslojs/crypto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@oslojs/crypto/-/crypto-1.0.1.tgz",
+      "integrity": "sha512-7n08G8nWjAr/Yu3vu9zzrd0L9XnrJfpMioQcvCMxBIiF5orECHe5/3J0jmXRVvgfqMm/+4oxlQ+Sq39COYLcNQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@oslojs/asn1": "1.0.0",
+        "@oslojs/binary": "1.0.0"
+      }
+    },
+    "node_modules/@oslojs/encoding": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@oslojs/encoding/-/encoding-1.1.0.tgz",
+      "integrity": "sha512-70wQhgYmndg4GCPxPPxPGevRKqTIJ2Nh4OkiMWmDAVYsTQ+Ta7Sq+rPevXyXGdzr30/qZBnyOalCszoMxlyldQ==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@oslojs/jwt": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@oslojs/jwt/-/jwt-0.2.0.tgz",
+      "integrity": "sha512-bLE7BtHrURedCn4Mco3ma9L4Y1GR2SMBuIvjWr7rmQ4/W/4Jy70TIAgZ+0nIlk0xHz1vNP8x8DCns45Sb2XRbg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@oslojs/encoding": "0.4.1"
+      }
+    },
+    "node_modules/@oslojs/jwt/node_modules/@oslojs/encoding": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@oslojs/encoding/-/encoding-0.4.1.tgz",
+      "integrity": "sha512-hkjo6MuIK/kQR5CrGNdAPZhS01ZCXuWDRJ187zh6qqF2+yMHZpD9fAYpX8q2bOO6Ryhl3XpCT6kUX76N8hhm4Q==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
@@ -2555,6 +2623,86 @@
         "win32"
       ]
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.0.0-beta.3.tgz",
+      "integrity": "sha512-0ifF3BjA1E8SY9C+nUew8RefNOIq0cDlYALPty4rhUm8Rrl6tCM8hBT4bhGhx7I7iXD0uAgt50lgo8dD73ACMw==",
+      "license": "MIT"
+    },
+    "node_modules/@supabase/auth-js": {
+      "version": "2.72.0",
+      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.72.0.tgz",
+      "integrity": "sha512-4+bnUrtTDK1YD0/FCx2YtMiQH5FGu9Jlf4IQi5kcqRwRwqp2ey39V61nHNdH86jm3DIzz0aZKiWfTW8qXk1swQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.14"
+      }
+    },
+    "node_modules/@supabase/functions-js": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.5.0.tgz",
+      "integrity": "sha512-SXBx6Jvp+MOBekeKFu+G11YLYPeVeGQl23eYyAG9+Ro0pQ1aIP0UZNIBxHKNHqxzR0L0n6gysNr2KT3841NATw==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.14"
+      }
+    },
+    "node_modules/@supabase/node-fetch": {
+      "version": "2.6.15",
+      "resolved": "https://registry.npmjs.org/@supabase/node-fetch/-/node-fetch-2.6.15.tgz",
+      "integrity": "sha512-1ibVeYUacxWYi9i0cf5efil6adJ9WRyZBLivgjs+AUpewx1F3xPi7gLgaASI2SmIQxPoCEjAsLAzKPgMJVgOUQ==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      }
+    },
+    "node_modules/@supabase/postgrest-js": {
+      "version": "1.21.4",
+      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-1.21.4.tgz",
+      "integrity": "sha512-TxZCIjxk6/dP9abAi89VQbWWMBbybpGWyvmIzTd79OeravM13OjR/YEYeyUOPcM1C3QyvXkvPZhUfItvmhY1IQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.14"
+      }
+    },
+    "node_modules/@supabase/realtime-js": {
+      "version": "2.15.5",
+      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.15.5.tgz",
+      "integrity": "sha512-/Rs5Vqu9jejRD8ZeuaWXebdkH+J7V6VySbCZ/zQM93Ta5y3mAmocjioa/nzlB6qvFmyylUgKVS1KpE212t30OA==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.13",
+        "@types/phoenix": "^1.6.6",
+        "@types/ws": "^8.18.1",
+        "ws": "^8.18.2"
+      }
+    },
+    "node_modules/@supabase/storage-js": {
+      "version": "2.12.2",
+      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.12.2.tgz",
+      "integrity": "sha512-SiySHxi3q7gia7NBYpsYRu8gyI0NhFwSORMxbZIxJ/zAVkN6QpwDRan158CJ+UdzD4WB/rQMAGRqIJQP+7ccAQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.14"
+      }
+    },
+    "node_modules/@supabase/supabase-js": {
+      "version": "2.58.0",
+      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.58.0.tgz",
+      "integrity": "sha512-Tm1RmQpoAKdQr4/8wiayGti/no+If7RtveVZjHR8zbO7hhQjmPW2Ok5ZBPf1MGkt5c+9R85AVMsTfSaqAP1sUg==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/auth-js": "2.72.0",
+        "@supabase/functions-js": "2.5.0",
+        "@supabase/node-fetch": "2.6.15",
+        "@supabase/postgrest-js": "1.21.4",
+        "@supabase/realtime-js": "2.15.5",
+        "@supabase/storage-js": "2.12.2"
+      }
+    },
     "node_modules/@swc/core": {
       "version": "1.13.2",
       "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.13.2.tgz",
@@ -2917,11 +3065,16 @@
       "version": "22.16.5",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.16.5.tgz",
       "integrity": "sha512-bJFoMATwIGaxxx8VJPeM8TonI8t579oRvgAuT8zFugJsJZgzqv0Fu8Mhp68iecjzG7cnN3mO2dJQ5uUM2EFrgQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
       }
+    },
+    "node_modules/@types/phoenix": {
+      "version": "1.6.6",
+      "resolved": "https://registry.npmjs.org/@types/phoenix/-/phoenix-1.6.6.tgz",
+      "integrity": "sha512-PIzZZlEppgrpoT2QgbnDU+MMzuR6BbCjllj0bM70lWoejMeNJAxCchxnv7J3XFkI8MpygtRpzXrIlmWUBclP5A==",
+      "license": "MIT"
     },
     "node_modules/@types/prop-types": {
       "version": "15.7.13",
@@ -2949,6 +3102,15 @@
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^18.0.0"
+      }
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
@@ -3309,6 +3471,18 @@
         "node": ">= 8"
       }
     },
+    "node_modules/arctic": {
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/arctic/-/arctic-2.3.4.tgz",
+      "integrity": "sha512-+p30BOWsctZp+CVYCt7oAean/hWGW42sH5LAcRQX56ttEkFJWbzXBhmSpibbzwSJkRrotmsA+oAoJoVsU0f5xA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@oslojs/crypto": "1.0.1",
+        "@oslojs/encoding": "1.1.0",
+        "@oslojs/jwt": "0.2.0"
+      }
+    },
     "node_modules/arg": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
@@ -3371,6 +3545,12 @@
       "peerDependencies": {
         "postcss": "^8.1.0"
       }
+    },
+    "node_modules/aws4fetch": {
+      "version": "1.0.20",
+      "resolved": "https://registry.npmjs.org/aws4fetch/-/aws4fetch-1.0.20.tgz",
+      "integrity": "sha512-/djoAN709iY65ETD6LKCtyyEI04XIBP5xVvfmNxsEP0uJB5tyaGBztSryRr4HqMStr9R06PisQE7m9zDTXKu6g==",
+      "license": "MIT"
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
@@ -4423,6 +4603,16 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/hono": {
+      "version": "4.9.9",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.9.9.tgz",
+      "integrity": "sha512-Hxw4wT6zjJGZJdkJzAx9PyBdf7ZpxaTSA0NfxqjLghwMrLBX8p33hJBzoETRakF3UJu6OdNQBZAlNSkGqKFukw==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -4573,6 +4763,15 @@
       "license": "MIT",
       "bin": {
         "jiti": "bin/jiti.js"
+      }
+    },
+    "node_modules/jose": {
+      "version": "5.9.6",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-5.9.6.tgz",
+      "integrity": "sha512-AMlnetc9+CV9asI19zHmrgS/WYsWUwCn2R7RzlbJWD7F9eWYUTGyBmU9o6PxngtLGOiDGPRu+Uc4fhKzbpteZQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/js-tokens": {
@@ -6348,6 +6547,12 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
     "node_modules/ts-api-utils": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.1.0.tgz",
@@ -6428,7 +6633,6 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/update-browserslist-db": {
@@ -6625,6 +6829,22 @@
         }
       }
     },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -6736,6 +6956,27 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.18.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/yaml": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "@fontsource/inter": "^5.2.8",
     "@hookform/resolvers": "^3.10.0",
+    "@openauthjs/openauth": "^0.4.3",
     "@radix-ui/react-accordion": "^1.2.11",
     "@radix-ui/react-alert-dialog": "^1.1.14",
     "@radix-ui/react-aspect-ratio": "^1.1.7",
@@ -40,6 +41,7 @@
     "@radix-ui/react-toggle": "^1.1.9",
     "@radix-ui/react-toggle-group": "^1.1.10",
     "@radix-ui/react-tooltip": "^1.2.7",
+    "@supabase/supabase-js": "^2.58.0",
     "@tanstack/react-query": "^5.83.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,6 +13,7 @@ import Profile from "./pages/Profile";
 import NotFound from "./pages/NotFound";
 import Games from "./pages/Games";
 import Achievements from "./pages/Achievements";
+import AuthCallback from "./pages/AuthCallback";
 import { AuthProvider } from "./contexts/AuthContext";
 import { TrackerProvider } from "./contexts/TrackerContext";
 
@@ -36,6 +37,7 @@ const App = () => (
                 <Route path="/activity" element={<Activity />} />
                 <Route path="/support" element={<Support />} />
                 <Route path="/profile" element={<Profile />} />
+                <Route path="/auth/callback" element={<AuthCallback />} />
                 <Route path="*" element={<NotFound />} />
               </Routes>
             </BrowserRouter>

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -1,9 +1,18 @@
-import { createContext, useCallback, useContext, useEffect, useMemo, useState } from "react";
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
+import { openAuthClient, isOpenAuthConfigured } from "@/lib/openauthClient";
+import { supabase, isSupabaseConfigured } from "@/lib/supabaseClient";
 
 export type AuthUser = {
   id: string;
   email: string;
-  password: string;
+  password?: string;
   displayName: string;
   avatarColor: string;
   bio: string;
@@ -14,14 +23,18 @@ export type AuthContextValue = {
   user: AuthUser | null;
   loading: boolean;
   users: AuthUser[];
-  register: (input: { email: string; password: string; displayName: string }) => Promise<void>;
-  login: (email: string, password: string) => Promise<void>;
-  logout: () => void;
-  updateProfile: (updates: Partial<Omit<AuthUser, "id" | "email" | "password">> & { password?: string }) => Promise<void>;
+  login: (email?: string, password?: string) => Promise<void>;
+  register: (input?: { email?: string; password?: string; displayName?: string }) => Promise<void>;
+  logout: () => Promise<void>;
+  updateProfile: (
+    updates: Partial<Omit<AuthUser, "id" | "email" | "password">> & { password?: string },
+  ) => Promise<void>;
+  beginLogin: (options?: { provider?: string; redirectTo?: string }) => Promise<void>;
+  completeLogin: (params: URLSearchParams) => Promise<void>;
+  usingOpenAuth: boolean;
 };
 
-const USERS_KEY = "gamevault-tracker-users";
-const SESSION_KEY = "gamevault-tracker-session";
+const AuthContext = createContext<AuthContextValue | undefined>(undefined);
 
 const defaultUser: AuthUser = {
   id: "demo-user",
@@ -33,39 +46,371 @@ const defaultUser: AuthUser = {
   privacy: "public",
 };
 
-const AuthContext = createContext<AuthContextValue | undefined>(undefined);
+const TOKENS_KEY = "gamevault-openauth-session";
+const CHALLENGE_KEY = "gamevault-openauth-challenge";
+
+const isBrowser = typeof window !== "undefined";
+
+type StoredTokens = {
+  access: string;
+  refresh: string;
+  expiresAt: number;
+};
+
+type TokenPayload = {
+  sub?: string;
+  email?: string;
+  name?: string;
+  picture?: string;
+};
+
+const decodeToken = (token: string): TokenPayload | null => {
+  try {
+    const [, payload] = token.split(".");
+    if (!payload) return null;
+    const normalised = payload.replace(/-/g, "+").replace(/_/g, "/");
+    const padded = normalised.padEnd(normalised.length + ((4 - (normalised.length % 4)) % 4), "=");
+    const decoded = isBrowser ? window.atob(padded) : Buffer.from(padded, "base64").toString("utf-8");
+    return JSON.parse(decoded) as TokenPayload;
+  } catch (error) {
+    console.error("Failed to decode access token", error);
+    return null;
+  }
+};
+
+const getStoredTokens = (): StoredTokens | null => {
+  if (!isBrowser) return null;
+  const raw = window.localStorage.getItem(TOKENS_KEY);
+  if (!raw) return null;
+  try {
+    const parsed = JSON.parse(raw) as StoredTokens;
+    if (!parsed.access || !parsed.refresh || !parsed.expiresAt) {
+      return null;
+    }
+    return parsed;
+  } catch (error) {
+    console.error("Failed to parse stored tokens", error);
+    return null;
+  }
+};
+
+const persistTokens = (tokens: StoredTokens | null) => {
+  if (!isBrowser) return;
+  if (!tokens) {
+    window.localStorage.removeItem(TOKENS_KEY);
+    return;
+  }
+  window.localStorage.setItem(TOKENS_KEY, JSON.stringify(tokens));
+};
+
+const storeChallenge = (challenge: unknown) => {
+  if (!isBrowser) return;
+  window.sessionStorage.setItem(CHALLENGE_KEY, JSON.stringify(challenge));
+};
+
+const readChallenge = (): { state: string; verifier?: string; redirectURI?: string } | null => {
+  if (!isBrowser) return null;
+  const raw = window.sessionStorage.getItem(CHALLENGE_KEY);
+  if (!raw) return null;
+  try {
+    return JSON.parse(raw) as { state: string; verifier?: string; redirectURI?: string };
+  } catch (error) {
+    console.error("Failed to parse stored challenge", error);
+    return null;
+  }
+};
+
+const clearChallenge = () => {
+  if (!isBrowser) return;
+  window.sessionStorage.removeItem(CHALLENGE_KEY);
+};
+
+const getDefaultRedirectURI = () => {
+  if (!isBrowser) return "";
+  return (
+    (import.meta.env.VITE_OPENAUTH_REDIRECT_URI as string | undefined) ??
+    `${window.location.origin}/auth/callback`
+  );
+};
+
+const formatProfile = (profile: {
+  id: string;
+  email?: string | null;
+  display_name?: string | null;
+  avatar_color?: string | null;
+  bio?: string | null;
+  privacy?: string | null;
+}): AuthUser => ({
+  id: profile.id,
+  email: profile.email ?? "",
+  displayName: profile.display_name ?? profile.email ?? "Player",
+  avatarColor: profile.avatar_color ?? "from-secondary to-primary",
+  bio: profile.bio ?? "",
+  privacy: (profile.privacy as AuthUser["privacy"]) ?? "friends",
+});
+
+const RemoteAuthProvider = ({ children }: { children: React.ReactNode }) => {
+  const [user, setUser] = useState<AuthUser | null>(null);
+  const [tokens, setTokens] = useState<StoredTokens | null>(() => getStoredTokens());
+  const [loading, setLoading] = useState(true);
+
+  const loadProfileFromTokens = useCallback(
+    async (session: StoredTokens | null) => {
+      if (!session) {
+        setUser(null);
+        return;
+      }
+      if (!supabase || !openAuthClient) {
+        setUser(null);
+        return;
+      }
+      const payload = decodeToken(session.access);
+      if (!payload?.sub) {
+        console.warn("Missing subject in OpenAuth token");
+        setUser(null);
+        return;
+      }
+      const identifier = payload.sub;
+      const email = payload.email ?? "";
+      const fallbackDisplay = payload.name ?? (email ? email.split("@")[0] : "Explorer");
+      try {
+        const { data, error } = await supabase
+          .from("profiles")
+          .select("id,email,display_name,avatar_color,bio,privacy")
+          .eq("id", identifier)
+          .maybeSingle();
+
+        if (error && error.code !== "PGRST116") {
+          throw error;
+        }
+
+        if (!data) {
+          const { data: created, error: insertError } = await supabase
+            .from("profiles")
+            .upsert(
+              {
+                id: identifier,
+                email,
+                display_name: fallbackDisplay,
+                avatar_color: "from-secondary to-primary",
+                bio: "",
+                privacy: "friends",
+              },
+              { onConflict: "id" },
+            )
+            .select("id,email,display_name,avatar_color,bio,privacy")
+            .single();
+
+          if (insertError) {
+            throw insertError;
+          }
+
+          setUser(formatProfile(created));
+          return;
+        }
+
+        setUser(formatProfile(data));
+      } catch (error) {
+        console.error("Failed to load profile from Supabase", error);
+        setUser(null);
+      }
+    },
+    [supabase, openAuthClient],
+  );
+
+  useEffect(() => {
+    let cancelled = false;
+    const initialise = async () => {
+      setLoading(true);
+      try {
+        await loadProfileFromTokens(tokens);
+      } finally {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      }
+    };
+    void initialise();
+    return () => {
+      cancelled = true;
+    };
+  }, [tokens, loadProfileFromTokens]);
+
+  const logout = useCallback(async () => {
+    setTokens(null);
+    persistTokens(null);
+    setUser(null);
+  }, []);
+
+  useEffect(() => {
+    if (!tokens || !openAuthClient || !isBrowser) return;
+    const timeout = window.setTimeout(async () => {
+      try {
+        const refreshed = await openAuthClient.refresh(tokens.refresh, { access: tokens.access });
+        if (refreshed.err) {
+          throw refreshed.err;
+        }
+        if (refreshed.tokens) {
+          const next: StoredTokens = {
+            access: refreshed.tokens.access,
+            refresh: refreshed.tokens.refresh,
+            expiresAt: Date.now() + refreshed.tokens.expiresIn * 1000,
+          };
+          setTokens(next);
+          persistTokens(next);
+        }
+      } catch (error) {
+        console.error("Failed to refresh OpenAuth session", error);
+        await logout();
+      }
+    }, Math.max(tokens.expiresAt - Date.now() - 60_000, 5_000));
+
+    return () => window.clearTimeout(timeout);
+  }, [tokens, logout]);
+
+  useEffect(() => {
+    persistTokens(tokens);
+  }, [tokens]);
+
+  const beginLogin = useCallback<AuthContextValue["beginLogin"]>(async (options) => {
+    if (!openAuthClient) {
+      throw new Error("OpenAuth client is not configured");
+    }
+    if (!isBrowser) return;
+    const redirectURI = options?.redirectTo ?? getDefaultRedirectURI();
+    const { challenge, url } = await openAuthClient.authorize(redirectURI, "code", {
+      pkce: true,
+      provider: options?.provider,
+    });
+    storeChallenge({ ...challenge, redirectURI });
+    window.location.href = url;
+  }, [openAuthClient]);
+
+  const completeLogin = useCallback<AuthContextValue["completeLogin"]>(async (params) => {
+    if (!openAuthClient) {
+      throw new Error("OpenAuth client is not configured");
+    }
+    const code = params.get("code");
+    const state = params.get("state");
+    if (!code || !state) {
+      throw new Error("Missing authorization response parameters");
+    }
+    const stored = readChallenge();
+    if (!stored) {
+      throw new Error("Sign-in session has expired. Start the flow again.");
+    }
+    if (stored.state !== state) {
+      throw new Error("Authorization state mismatch");
+    }
+    const redirectURI = stored.redirectURI ?? getDefaultRedirectURI();
+    const exchanged = await openAuthClient.exchange(code, redirectURI, stored.verifier);
+    if (exchanged.err) {
+      throw exchanged.err;
+    }
+    const session: StoredTokens = {
+      access: exchanged.tokens.access,
+      refresh: exchanged.tokens.refresh,
+      expiresAt: Date.now() + exchanged.tokens.expiresIn * 1000,
+    };
+    clearChallenge();
+    setTokens(session);
+    persistTokens(session);
+  }, [openAuthClient]);
+
+  const login = useCallback<AuthContextValue["login"]>(async () => {
+    await beginLogin();
+  }, [beginLogin]);
+
+  const register = useCallback<AuthContextValue["register"]>(async () => {
+    await beginLogin();
+  }, [beginLogin]);
+
+  const updateProfile = useCallback<AuthContextValue["updateProfile"]>(
+    async (updates) => {
+      if (!supabase) {
+        throw new Error("Supabase client is not configured");
+      }
+      if (!user) return;
+      const payload = {
+        display_name: updates.displayName ?? user.displayName,
+        avatar_color: updates.avatarColor ?? user.avatarColor,
+        bio: updates.bio ?? user.bio,
+        privacy: updates.privacy ?? user.privacy,
+      };
+      const { data, error } = await supabase
+        .from("profiles")
+        .update(payload)
+        .eq("id", user.id)
+        .select("id,email,display_name,avatar_color,bio,privacy")
+        .single();
+      if (error) {
+        throw error;
+      }
+      setUser(formatProfile(data));
+    },
+    [user, supabase],
+  );
+
+  const value = useMemo<AuthContextValue>(
+    () => ({
+      user,
+      loading,
+      users: user ? [user] : [],
+      login,
+      register,
+      logout,
+      updateProfile,
+      beginLogin,
+      completeLogin,
+      usingOpenAuth: true,
+    }),
+    [user, loading, login, register, logout, updateProfile, beginLogin, completeLogin],
+  );
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+};
+
+const USERS_KEY = "gamevault-tracker-users";
+const SESSION_KEY = "gamevault-tracker-session";
+
+type LocalAuthProviderProps = {
+  children: React.ReactNode;
+};
+
+const loadUsers = (): AuthUser[] => {
+  if (!isBrowser) {
+    return [defaultUser];
+  }
+  const raw = window.localStorage.getItem(USERS_KEY);
+  if (!raw) {
+    window.localStorage.setItem(USERS_KEY, JSON.stringify([defaultUser]));
+    return [defaultUser];
+  }
+  try {
+    const parsed = JSON.parse(raw) as AuthUser[];
+    if (!parsed.length) {
+      window.localStorage.setItem(USERS_KEY, JSON.stringify([defaultUser]));
+      return [defaultUser];
+    }
+    return parsed;
+  } catch (error) {
+    console.error("Failed to parse stored users", error);
+    window.localStorage.setItem(USERS_KEY, JSON.stringify([defaultUser]));
+    return [defaultUser];
+  }
+};
+
+const persistUsers = (users: AuthUser[]) => {
+  if (!isBrowser) return;
+  window.localStorage.setItem(USERS_KEY, JSON.stringify(users));
+};
 
 const createId = () =>
   typeof crypto !== "undefined" && "randomUUID" in crypto
     ? crypto.randomUUID()
     : `id-${Math.random().toString(36).slice(2, 11)}`;
 
-const loadUsers = (): AuthUser[] => {
-  const raw = localStorage.getItem(USERS_KEY);
-  if (!raw) {
-    localStorage.setItem(USERS_KEY, JSON.stringify([defaultUser]));
-    return [defaultUser];
-  }
-
-  try {
-    const parsed = JSON.parse(raw) as AuthUser[];
-    if (!parsed.length) {
-      localStorage.setItem(USERS_KEY, JSON.stringify([defaultUser]));
-      return [defaultUser];
-    }
-    return parsed;
-  } catch (error) {
-    console.error("Failed to parse stored users", error);
-    localStorage.setItem(USERS_KEY, JSON.stringify([defaultUser]));
-    return [defaultUser];
-  }
-};
-
-const persistUsers = (users: AuthUser[]) => {
-  localStorage.setItem(USERS_KEY, JSON.stringify(users));
-};
-
-export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
+const LocalAuthProvider = ({ children }: LocalAuthProviderProps) => {
   const [users, setUsers] = useState<AuthUser[]>([]);
   const [user, setUser] = useState<AuthUser | null>(null);
   const [loading, setLoading] = useState(true);
@@ -73,8 +418,7 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
   useEffect(() => {
     const storedUsers = loadUsers();
     setUsers(storedUsers);
-
-    const sessionId = localStorage.getItem(SESSION_KEY);
+    const sessionId = isBrowser ? window.localStorage.getItem(SESSION_KEY) : null;
     if (sessionId) {
       const existing = storedUsers.find((u) => u.id === sessionId);
       setUser(existing ?? null);
@@ -82,48 +426,58 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
     setLoading(false);
   }, []);
 
-  const register = useCallback(async ({ email, password, displayName }: { email: string; password: string; displayName: string }) => {
-    setUsers((prev) => {
-      if (prev.some((u) => u.email.toLowerCase() === email.toLowerCase())) {
-        throw new Error("An account with that email already exists");
+  const register = useCallback<Required<AuthContextValue>["register"]>(
+    async ({ email, password, displayName } = {}) => {
+      if (!email || !password || !displayName) {
+        throw new Error("Email, password and display name are required");
       }
-      const newUser: AuthUser = {
-        id: `user-${createId()}`,
-        email,
-        password,
-        displayName,
-        avatarColor: "from-secondary to-primary",
-        bio: "",
-        privacy: "friends",
-      };
-      const next = [...prev, newUser];
-      persistUsers(next);
-      localStorage.setItem(SESSION_KEY, newUser.id);
-      setUser(newUser);
-      return next;
-    });
-  }, []);
+      setUsers((prev) => {
+        if (prev.some((u) => u.email.toLowerCase() === email.toLowerCase())) {
+          throw new Error("An account with that email already exists");
+        }
+        const newUser: AuthUser = {
+          id: `user-${createId()}`,
+          email,
+          password,
+          displayName,
+          avatarColor: "from-secondary to-primary",
+          bio: "",
+          privacy: "friends",
+        };
+        const next = [...prev, newUser];
+        persistUsers(next);
+        if (isBrowser) {
+          window.localStorage.setItem(SESSION_KEY, newUser.id);
+        }
+        setUser(newUser);
+        return next;
+      });
+    },
+    [],
+  );
 
-  const login = useCallback(async (email: string, password: string) => {
-    const match = users.find((u) => u.email.toLowerCase() === email.toLowerCase() && u.password === password);
+  const login = useCallback<Required<AuthContextValue>["login"]>(async (email, password) => {
+    const match = users.find(
+      (u) => u.email.toLowerCase() === (email ?? "").toLowerCase() && u.password === password,
+    );
     if (!match) {
       throw new Error("Invalid credentials");
     }
-    localStorage.setItem(SESSION_KEY, match.id);
+    if (isBrowser) {
+      window.localStorage.setItem(SESSION_KEY, match.id);
+    }
     setUser(match);
   }, [users]);
 
-  const logout = useCallback(() => {
-    localStorage.removeItem(SESSION_KEY);
+  const logout = useCallback(async () => {
+    if (isBrowser) {
+      window.localStorage.removeItem(SESSION_KEY);
+    }
     setUser(null);
   }, []);
 
-  const updateProfile = useCallback(
-    async (
-      updates: Partial<Omit<AuthUser, "id" | "email" | "password">> & {
-        password?: string;
-      },
-    ) => {
+  const updateProfile = useCallback<AuthContextValue["updateProfile"]>(
+    async (updates) => {
       if (!user) return;
       setUsers((prev) => {
         const next = prev.map((u) => {
@@ -143,17 +497,39 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
     [user],
   );
 
-  const value = useMemo<AuthContextValue>(() => ({
-    user,
-    loading,
-    users,
-    register,
-    login,
-    logout,
-    updateProfile,
-  }), [user, loading, users, register, login, logout, updateProfile]);
+  const beginLogin = useCallback<AuthContextValue["beginLogin"]>(async () => {
+    // Local mode simply presents the inline login form.
+    return;
+  }, []);
+
+  const completeLogin = useCallback<AuthContextValue["completeLogin"]>(async () => {
+    return;
+  }, []);
+
+  const value = useMemo<AuthContextValue>(
+    () => ({
+      user,
+      loading,
+      users,
+      login,
+      register,
+      logout,
+      updateProfile,
+      beginLogin,
+      completeLogin,
+      usingOpenAuth: false,
+    }),
+    [user, loading, users, login, register, logout, updateProfile, beginLogin, completeLogin],
+  );
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+};
+
+export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
+  if (isSupabaseConfigured && isOpenAuthConfigured) {
+    return <RemoteAuthProvider>{children}</RemoteAuthProvider>;
+  }
+  return <LocalAuthProvider>{children}</LocalAuthProvider>;
 };
 
 export const useAuth = () => {

--- a/src/lib/openauthClient.ts
+++ b/src/lib/openauthClient.ts
@@ -1,0 +1,20 @@
+import { createClient, type Client } from "@openauthjs/openauth/client";
+
+const issuer = import.meta.env.VITE_OPENAUTH_ISSUER as string | undefined;
+const clientID = import.meta.env.VITE_OPENAUTH_CLIENT_ID as string | undefined;
+
+let client: Client | null = null;
+
+if (issuer && clientID) {
+  client = createClient({
+    issuer,
+    clientID,
+  });
+} else if (import.meta.env.DEV) {
+  console.warn(
+    "OpenAuth client is not configured. Set VITE_OPENAUTH_ISSUER and VITE_OPENAUTH_CLIENT_ID to enable OpenAuth flows.",
+  );
+}
+
+export const openAuthClient = client;
+export const isOpenAuthConfigured = client !== null;

--- a/src/lib/supabaseClient.ts
+++ b/src/lib/supabaseClient.ts
@@ -1,0 +1,21 @@
+import { createClient, type SupabaseClient } from "@supabase/supabase-js";
+
+const supabaseUrl = import.meta.env.VITE_SUPABASE_URL as string | undefined;
+const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY as string | undefined;
+
+let client: SupabaseClient | null = null;
+
+if (supabaseUrl && supabaseAnonKey) {
+  client = createClient(supabaseUrl, supabaseAnonKey, {
+    auth: {
+      persistSession: false,
+    },
+  });
+} else if (import.meta.env.DEV) {
+  console.warn(
+    "Supabase client is not configured. Set VITE_SUPABASE_URL and VITE_SUPABASE_ANON_KEY to enable database syncing.",
+  );
+}
+
+export const supabase = client;
+export const isSupabaseConfigured = client !== null;

--- a/src/pages/AuthCallback.tsx
+++ b/src/pages/AuthCallback.tsx
@@ -1,0 +1,81 @@
+import { useEffect, useState } from "react";
+import { useNavigate, useSearchParams } from "react-router-dom";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Loader2 } from "lucide-react";
+import { useAuth } from "@/contexts/AuthContext";
+
+const AuthCallback = () => {
+  const { completeLogin } = useAuth();
+  const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+  const [error, setError] = useState<string | null>(null);
+  const [status, setStatus] = useState<"pending" | "success" | "error">("pending");
+
+  useEffect(() => {
+    let cancelled = false;
+    const run = async () => {
+      try {
+        await completeLogin(searchParams);
+        if (cancelled) return;
+        setStatus("success");
+        setTimeout(() => {
+          navigate("/profile", { replace: true });
+        }, 800);
+      } catch (err) {
+        if (cancelled) return;
+        setStatus("error");
+        setError(err instanceof Error ? err.message : "Unable to complete sign-in.");
+      }
+    };
+    void run();
+    return () => {
+      cancelled = true;
+    };
+  }, [completeLogin, navigate, searchParams]);
+
+  const handleRetry = () => {
+    navigate("/profile", { replace: true });
+  };
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-background px-4">
+      <Card className="w-full max-w-md">
+        <CardHeader>
+          <CardTitle>Finishing sign-in</CardTitle>
+          <CardDescription>
+            {status === "pending"
+              ? "Verifying your OpenAuth credentials."
+              : status === "success"
+                ? "You're all set! Redirecting back to your profile."
+                : "We couldn't complete the sign-in flow."}
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4 text-sm text-muted-foreground">
+          {status === "pending" && (
+            <div className="flex items-center justify-center gap-2">
+              <Loader2 className="h-4 w-4 animate-spin" />
+              <span>Finalising authentication&hellip;</span>
+            </div>
+          )}
+          {status === "error" && (
+            <div className="space-y-3">
+              <p>{error}</p>
+              <Button onClick={handleRetry} className="w-full">
+                Return to profile
+              </Button>
+            </div>
+          )}
+          {status === "success" && (
+            <div className="flex items-center justify-center gap-2">
+              <Loader2 className="h-4 w-4 animate-spin" />
+              <span>Redirecting&hellip;</span>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+};
+
+export default AuthCallback;


### PR DESCRIPTION
## Summary
- add Supabase and OpenAuth client helpers plus environment template for hosted configuration
- refactor authentication and tracker contexts to sync users/data with Supabase and support the OpenAuth redirect flow and callback page
- refresh the profile sign-in UI and documentation with instructions for configuring Supabase tables and OpenAuth providers

## Testing
- npm run build
- npm run lint *(fails: pre-existing eslint rule violations in shared UI components and Tailwind config)*

------
https://chatgpt.com/codex/tasks/task_e_68de9502a4d4832daf33b125ef9971a9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Optional sign-in via OpenAuth + Supabase, including a new authentication callback route.
  - Profile page now supports OpenAuth-based login with redirect and status feedback.
  - Tracker data can sync to Supabase when configured; falls back to local storage otherwise.

- Documentation
  - Added “Connecting Supabase & OpenAuth” guide with setup steps, environment variables, and fallback behavior.

- Chores
  - Added sample environment configuration variables for Supabase and OpenAuth.
  - Introduced dependencies for OpenAuth and Supabase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->