### PR TITLE
Allow authenticated users to create profiles

### DIFF
--- a/supabase/migrations/20251005120000_allow_profile_insert.sql
+++ b/supabase/migrations/20251005120000_allow_profile_insert.sql
@@ -1,0 +1,4 @@
+-- Allow authenticated users to provision their own profile record.
+create policy "Users insert own profile" on public.profiles
+  for insert
+  with check (external_id = public.current_user_external_id());


### PR DESCRIPTION
## Summary
- add a row-level security policy that allows newly registered users to insert their own profile records
- unblock Supabase registration flow by permitting the auth subject to create a matching profile row

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690e1c7d5e18832da3132b677e1d8ea6)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Strengthened database security controls for user profile creation and management, ensuring users can only modify their own profile information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->