### PR TITLE
Preserve Supabase profile display names

### DIFF
--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -8,7 +8,7 @@ import {
 } from "react";
 
 import { getSupabaseClient } from "@/lib/api/supabaseClient";
-import type { SupabaseClient } from "@supabase/supabase-js";
+import type { SupabaseClient, User as SupabaseUser } from "@supabase/supabase-js";
 
 export type AuthUser = {
   id: string;
@@ -67,6 +67,13 @@ function mapProfileToAuthUser(profile: any, fallbackEmail: string): AuthUser {
     bio: profile?.bio ?? "",
     privacy: "friends",
   };
+}
+
+function extractDisplayNameFromMetadata(
+  authUser: Pick<SupabaseUser, "user_metadata">
+): string | undefined {
+  const raw = authUser.user_metadata?.display_name;
+  return typeof raw === "string" && raw.trim() ? raw : undefined;
 }
 
 async function ensureProfileForUser(
@@ -155,6 +162,7 @@ const SupabaseAuthProvider = ({ children }: { children: React.ReactNode }) => {
         const profile = await ensureProfileForUser(supabase, {
           userId: authUser.id,
           email: authUser.email ?? "",
+          displayName: extractDisplayNameFromMetadata(authUser),
         });
 
         if (!cancelled) {
@@ -180,6 +188,7 @@ const SupabaseAuthProvider = ({ children }: { children: React.ReactNode }) => {
         const profile = await ensureProfileForUser(supabase, {
           userId: authUser.id,
           email: authUser.email ?? "",
+          displayName: extractDisplayNameFromMetadata(authUser),
         });
 
         setUser(
@@ -278,6 +287,7 @@ const SupabaseAuthProvider = ({ children }: { children: React.ReactNode }) => {
       const profile = await ensureProfileForUser(supabase, {
         userId: authUser.id,
         email: authUser.email ?? email,
+        displayName: extractDisplayNameFromMetadata(authUser),
       });
 
       setUser(


### PR DESCRIPTION
## Summary
- pull the preferred display name from Supabase user metadata when hydrating profiles
- reuse the stored metadata during auth state changes so profiles keep the chosen name after email verification

## Testing
- npm run lint *(fails: missing @eslint/js in repo)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690e25d7abe4832d96d442d995f122ca)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved how user display names are populated from authentication data for better accuracy during profile creation and updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->